### PR TITLE
Refactor py3 to remove 'import past'

### DIFF
--- a/lib/pycaption/base.py
+++ b/lib/pycaption/base.py
@@ -4,8 +4,6 @@ from builtins import object
 from datetime import timedelta
 from numbers import Number
 
-from past.utils import old_div
-
 import six
 
 from .exceptions import CaptionReadError, CaptionReadTimingError
@@ -235,7 +233,7 @@ class Caption(object):
         return u''.join(text_nodes).strip()
 
     def _format_timestamp(self, value, msec_separator=None):
-        datetime_value = timedelta(milliseconds=(int(old_div(value, 1000))))
+        datetime_value = timedelta(milliseconds=(value // 1000))
 
         str_value = six.text_type(datetime_value)[:11]
         if not datetime_value.microseconds:

--- a/lib/pycaption/dfxp/base.py
+++ b/lib/pycaption/dfxp/base.py
@@ -7,8 +7,6 @@ from xml.sax.saxutils import escape
 
 from bs4 import BeautifulSoup, NavigableString
 
-from past.utils import old_div
-
 import six
 
 from ..base import (
@@ -143,7 +141,7 @@ class DFXPReader(BaseReader):
                 timesplit[2] = timesplit[2] + u'.000'
             secsplit = timesplit[2].split(u'.')
             if len(timesplit) > 3:
-                secsplit.append((old_div(int(timesplit[3]), 30)) * 100)
+                secsplit.append((timesplit[3] // 30) * 100)
             while len(secsplit[1]) < 3:
                 secsplit[1] += u'0'
             microseconds = (int(timesplit[0]) * 3600000000 +

--- a/lib/pycaption/geometry.py
+++ b/lib/pycaption/geometry.py
@@ -10,10 +10,7 @@ CONVENTIONS:
 from __future__ import division, unicode_literals
 
 from builtins import object
-
 from past.builtins import cmp
-from past.utils import old_div
-
 import six
 
 from .exceptions import RelativizationError
@@ -497,7 +494,7 @@ class Size(object):
             unit = UnitEnum.PIXEL
 
         if unit == UnitEnum.PIXEL:
-            value = old_div(value * 100.0, (video_width or video_height))
+            value = (value * 100.0) / (video_width or video_height)
             unit = UnitEnum.PERCENT
 
         if unit == UnitEnum.CELL:
@@ -505,7 +502,7 @@ class Size(object):
             # (w3.org/TR/ttaf1-dfxp/#parameter-attribute-cellResolution)
             # For now we will use the default values (32 columns and 15 rows)
             cell_reference = 32 if video_width else 15
-            value = old_div(value * 100.0, cell_reference)
+            value = (value * 100.0) / cell_reference
             unit = UnitEnum.PERCENT
 
         return Size(value, unit)

--- a/lib/pycaption/geometry.py
+++ b/lib/pycaption/geometry.py
@@ -10,7 +10,6 @@ CONVENTIONS:
 from __future__ import division, unicode_literals
 
 from builtins import object
-from past.builtins import cmp
 import six
 
 from .exceptions import RelativizationError
@@ -442,7 +441,7 @@ class Size(object):
 
     def __cmp__(self, other):
         if self.unit == other.unit:
-            return cmp(self.value, other.value)
+            return (self.value > other.value) - (self.value < other.value)
         else:
             raise ValueError(u"The sizes should have the same measure units.")
 

--- a/lib/pycaption/scc/__init__.py
+++ b/lib/pycaption/scc/__init__.py
@@ -87,8 +87,6 @@ import textwrap
 from builtins import object, range
 from copy import deepcopy
 
-from past.utils import old_div
-
 from pycaption.base import (
     BaseReader, BaseWriter, CaptionNode, CaptionSet
 )
@@ -524,7 +522,7 @@ class SCCWriter(BaseWriter):
         # Advance start times so as to have time to write to the pop-on
         # buffer; possibly remove the previous clear-screen command
         for index, (code, start, end) in enumerate(codes):
-            code_words = old_div(len(code), 5) + 8
+            code_words = len(code) // 5 + 8
             code_time_microseconds = code_words * MICROSECONDS_PER_CODEWORD
             code_start = start - code_time_microseconds
             if index == 0:
@@ -611,9 +609,9 @@ class SCCWriter(BaseWriter):
         seconds_float = microseconds / 1000.0 / 1000.0
         # Convert to non-drop-frame timecode
         seconds_float *= 1000.0 / 1001.0
-        hours = math.floor(old_div(seconds_float, 3600))
+        hours = seconds_float // 3600
         seconds_float -= hours * 3600
-        minutes = math.floor(old_div(seconds_float, 60))
+        minutes = seconds_float // 60
         seconds_float -= minutes * 60
         seconds = math.floor(seconds_float)
         seconds_float -= seconds

--- a/lib/pycaption/webvtt.py
+++ b/lib/pycaption/webvtt.py
@@ -5,8 +5,6 @@ import re
 import sys
 from copy import deepcopy
 
-from past.utils import old_div
-
 from pycaption.geometry import HorizontalAlignmentEnum
 
 import six
@@ -389,7 +387,7 @@ class WebVTTWriter(BaseWriter):
             # in VTT, the origin of the cue box is the center, not the left
             # top corner
             position = left_offset.value + (
-                old_div(cue_width.value, 2)) if cue_width else 50
+                cue_width.value / 2 ) if cue_width else 50
             cue_settings += " position:{}".format(
                 six.text_type(Size(position, UnitEnum.PERCENT)))
         if top_offset:


### PR DESCRIPTION
My base install of CoreELEC does not include lib2to3.

Refactored to remove 'import past'

Upstream pull here, but there are many unaddressed PR there: pbs/pycaption#193

Cheers
